### PR TITLE
Simplify the communicator's name caching management

### DIFF
--- a/ompi/mca/common/monitoring/common_monitoring.h
+++ b/ompi/mca/common/monitoring/common_monitoring.h
@@ -110,6 +110,7 @@ typedef struct mca_monitoring_coll_data_t mca_monitoring_coll_data_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_monitoring_coll_data_t);
 
 OMPI_DECLSPEC mca_monitoring_coll_data_t*mca_common_monitoring_coll_new(ompi_communicator_t*comm);
+OMPI_DECLSPEC int  mca_common_monitoring_coll_cache_name(ompi_communicator_t*comm);
 OMPI_DECLSPEC void mca_common_monitoring_coll_release(mca_monitoring_coll_data_t*data);
 OMPI_DECLSPEC void mca_common_monitoring_coll_o2a(size_t size, mca_monitoring_coll_data_t*data);
 OMPI_DECLSPEC void mca_common_monitoring_coll_a2o(size_t size, mca_monitoring_coll_data_t*data);

--- a/ompi/mca/pml/monitoring/pml_monitoring_comm.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_comm.c
@@ -20,5 +20,6 @@ int mca_pml_monitoring_add_comm(struct ompi_communicator_t* comm)
 
 int mca_pml_monitoring_del_comm(struct ompi_communicator_t* comm)
 {
+    mca_common_monitoring_coll_cache_name(comm);
     return pml_selected_module.pml_del_comm(comm);
 }


### PR DESCRIPTION
Keeps tracks of the communicator until it is actually desallocated, at which point the name is cached.

Signed-off-by: Clement Foyer <clement.foyer@inria.fr>