### PR TITLE
ompi/request: fix a segfault in multi-threaded mode.

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_ibcast.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ibcast.c
@@ -162,7 +162,7 @@ static int send_cb(ompi_request_t *req)
         opal_free_list_return(mca_coll_adapt_component.adapt_ibcast_context_free_list, (opal_free_list_item_t*)context);
         OPAL_THREAD_UNLOCK(mutex_temp);
     }
-    OPAL_THREAD_UNLOCK(req->req_lock);
+    OPAL_THREAD_UNLOCK(&(req->req_lock));
     req->req_free(&req);
     return 1;
 }
@@ -255,7 +255,7 @@ static int recv_cb(ompi_request_t *req){
         opal_free_list_return(mca_coll_adapt_component.adapt_ibcast_context_free_list, (opal_free_list_item_t*)context);
         OPAL_THREAD_UNLOCK(mutex_temp);
     }
-    OPAL_THREAD_UNLOCK(req->req_lock);
+    OPAL_THREAD_UNLOCK(&(req->req_lock));
     req->req_free(&req);
     return 1;
 }

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -256,7 +256,7 @@ static int send_cb(ompi_request_t *req){
         OPAL_OUTPUT_VERBOSE((30, mca_coll_adapt_component.adapt_output,"return context_list\n"));
         opal_free_list_return(mca_coll_adapt_component.adapt_ireduce_context_free_list, (opal_free_list_item_t*)context);
     }
-    OPAL_THREAD_UNLOCK(req->req_lock);
+    OPAL_THREAD_UNLOCK(&(req->req_lock));
     req->req_free(&req);
     return 1;
 }
@@ -413,7 +413,7 @@ static int recv_cb(ompi_request_t *req){
         OPAL_OUTPUT_VERBOSE((30, mca_coll_adapt_component.adapt_output, "[%d]: return context_list", context->con->rank));
         opal_free_list_return(mca_coll_adapt_component.adapt_ireduce_context_free_list, (opal_free_list_item_t*)context);
     }
-    OPAL_THREAD_UNLOCK(req->req_lock);
+    OPAL_THREAD_UNLOCK(&(req->req_lock));
     req->req_free(&req);
     return 1;
 }

--- a/ompi/mca/coll/adapt/coll_adapt_module.c
+++ b/ompi/mca/coll/adapt/coll_adapt_module.c
@@ -189,9 +189,9 @@ void print_tree(ompi_coll_tree_t* tree, int rank)
 
 int adapt_request_free(ompi_request_t** request)
 {
-    OPAL_THREAD_LOCK ((*request)->req_lock);
+    OPAL_THREAD_LOCK (&((*request)->req_lock));
     (*request)->req_state = OMPI_REQUEST_INVALID;
-    OPAL_THREAD_UNLOCK ((*request)->req_lock);
+    OPAL_THREAD_UNLOCK (&((*request)->req_lock));
     OBJ_RELEASE(*request);
     *request = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;

--- a/ompi/mca/coll/future/coll_future_module.c
+++ b/ompi/mca/coll/future/coll_future_module.c
@@ -224,9 +224,9 @@ int ompi_coll_future_lazy_enable(mca_coll_base_module_t *module,
 
 int future_request_free(ompi_request_t** request)
 {
-    OPAL_THREAD_LOCK ((*request)->req_lock);
+    OPAL_THREAD_LOCK (&((*request)->req_lock));
     (*request)->req_state = OMPI_REQUEST_INVALID;
-    OPAL_THREAD_UNLOCK ((*request)->req_lock);
+    OPAL_THREAD_UNLOCK (&((*request)->req_lock));
     OBJ_RELEASE(*request);
     *request = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -135,7 +135,7 @@ struct ompi_request_t {
     ompi_request_complete_fn_t req_complete_cb; /**< Called when the request is MPI completed */
     void *req_complete_cb_data;
     ompi_mpi_object_t req_mpi_object;           /**< Pointer to MPI object that created this request */
-    opal_mutex_t *req_lock;                   //lock the request for request_complete and set_callback
+    opal_mutex_t req_lock;                      /**< lock the request for request_complete and set_callback */
 
 };
 
@@ -452,12 +452,13 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
     
     //    printf("[%" PRIx64 "]: In request complete 0: req %p, req_complete_cb no null %d, req_complete %d, rc %d\n", gettid(), (void *)request, NULL != request->req_complete_cb, request->req_complete == REQUEST_COMPLETED, rc);
     //printf("[%" PRIx64 ", request %p]: ompi_request_complete lock \n", gettid(), (void *)request);
-    OPAL_THREAD_LOCK(request->req_lock);
+    OPAL_THREAD_LOCK(&(request->req_lock));
     if(NULL != request->req_complete_cb) {
         ompi_request_complete_fn_t temp = request->req_complete_cb;
         request->req_complete_cb = NULL;
         rc = temp( request );
         if (rc >= 1) {
+            OPAL_THREAD_UNLOCK(&(request->req_lock));
             return rc;
         }
     }
@@ -481,7 +482,7 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
     }
     
     //printf("[%" PRIx64 ", request %p]: ompi_request_complete unlock \n", gettid(), (void *)request);
-    OPAL_THREAD_UNLOCK(request->req_lock);
+    OPAL_THREAD_UNLOCK(&(request->req_lock));
     return OMPI_SUCCESS;
 }
 
@@ -489,7 +490,7 @@ static inline int ompi_request_set_callback(ompi_request_t* request,
                                             ompi_request_complete_fn_t cb,
                                             void* cb_data)
 {
-    OPAL_THREAD_LOCK (request->req_lock);
+    OPAL_THREAD_LOCK (&(request->req_lock));
     request->req_complete_cb_data = cb_data;
     request->req_complete_cb = cb;
     int rc = 0;
@@ -500,10 +501,11 @@ static inline int ompi_request_set_callback(ompi_request_t* request,
         request->req_complete_cb = NULL;
         rc = temp( request );
         if (rc >= 1) {
+            OPAL_THREAD_UNLOCK(&(request->req_lock));
             return rc;
         }
     }
-    OPAL_THREAD_UNLOCK (request->req_lock);
+    OPAL_THREAD_UNLOCK (&(request->req_lock));
     return rc;
 }
 

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -458,7 +458,11 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
         request->req_complete_cb = NULL;
         rc = temp( request );
         if (rc >= 1) {
-            OPAL_THREAD_UNLOCK(&(request->req_lock));
+            /*
+             * The callback routine succeeded: in that case it has released
+             * the req_lock and freed the request.
+             * ==> No need to do it here.
+             */
             return rc;
         }
     }
@@ -501,7 +505,11 @@ static inline int ompi_request_set_callback(ompi_request_t* request,
         request->req_complete_cb = NULL;
         rc = temp( request );
         if (rc >= 1) {
-            OPAL_THREAD_UNLOCK(&(request->req_lock));
+            /*
+             * The callback routine succeeded: in that case it has released
+             * the req_lock and freed the request.
+             * ==> No need to do it here.
+             */
             return rc;
         }
     }


### PR DESCRIPTION
   in commit 976de7c53e3bfb28a448af89218a6f8f9af8cf9a, a lock has been
   added to the ompi_request_t structure.
   It was defined as a pointer to a mutex lock, and never allocated.
   ==> just calling MPI_Init_thread(MPI_THREAD_MULTIPLE) produced
       segfault, since the lock was taken w/o being allocated.
   This commit fixes the issue.