### PR TITLE
ADAPT: use the correct nbc request type

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -720,19 +720,19 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
         next_recv_segs = NULL;
     }
 
-    ompi_request_t *temp_request = NULL;
+    ompi_coll_base_nbc_request_t *temp_request = NULL;
     /* Set up request */
-    temp_request = OBJ_NEW(ompi_request_t);
-    OMPI_REQUEST_INIT(temp_request, false);
-    temp_request->req_state = OMPI_REQUEST_ACTIVE;
-    temp_request->req_type = OMPI_REQUEST_COLL;
-    temp_request->req_free = ompi_coll_adapt_request_free;
-    temp_request->req_status.MPI_SOURCE = 0;
-    temp_request->req_status.MPI_TAG = 0;
-    temp_request->req_status.MPI_ERROR = 0;
-    temp_request->req_status._cancelled = 0;
-    temp_request->req_status._ucount = 0;
-    *request = temp_request;
+    temp_request = OBJ_NEW(ompi_coll_base_nbc_request_t);
+    OMPI_REQUEST_INIT(&temp_request->super, false);
+    temp_request->super.req_state = OMPI_REQUEST_ACTIVE;
+    temp_request->super.req_type = OMPI_REQUEST_COLL;
+    temp_request->super.req_free = ompi_coll_adapt_request_free;
+    temp_request->super.req_status.MPI_SOURCE = 0;
+    temp_request->super.req_status.MPI_TAG = 0;
+    temp_request->super.req_status.MPI_ERROR = 0;
+    temp_request->super.req_status._cancelled = 0;
+    temp_request->super.req_status._ucount = 0;
+    *request = (ompi_request_t*)temp_request;
 
     /* Set up mutex */
     mutex_recv_list = OBJ_NEW(opal_mutex_t);
@@ -754,7 +754,7 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, int count,
     con->comm = comm;
     con->segment_increment = segment_increment;
     con->num_segs = num_segs;
-    con->request = temp_request;
+    con->request = (ompi_request_t*)temp_request;
     con->rank = rank;
     con->num_recv_segs = 0;
     con->num_sent_segs = 0;

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -34,6 +34,10 @@
 
 BEGIN_C_DECLS
 
+/**
+ * Request structure to be returned by non-blocking
+ * collective operations.
+ */
 struct ompi_coll_base_nbc_request_t {
     ompi_request_t super;
     union {
@@ -133,14 +137,29 @@ unsigned int ompi_mirror_perm(unsigned int x, int nbits);
  */
 int ompi_rounddown(int num, int factor);
 
+/**
+ * If necessary, retain op and store it in the
+ * request object, which should be of type ompi_coll_base_nbc_request_t
+ * (will be cast internally).
+ */
 int ompi_coll_base_retain_op( ompi_request_t *request,
                               ompi_op_t *op,
                               ompi_datatype_t *type);
 
+/**
+ * If necessary, retain the datatypes and store them in the
+ * request object, which should be of type ompi_coll_base_nbc_request_t
+ * (will be cast internally).
+ */
 int ompi_coll_base_retain_datatypes( ompi_request_t *request,
                                       ompi_datatype_t *stype,
                                      ompi_datatype_t *rtype);
 
+/**
+ * If necessary, retain the datatypes and store them in the
+ * request object, which should be of type ompi_coll_base_nbc_request_t
+ * (will be cast internally).
+ */
 int ompi_coll_base_retain_datatypes_w( ompi_request_t *request,
                                        ompi_datatype_t * const stypes[],
                                        ompi_datatype_t * const rtypes[]);


### PR DESCRIPTION
ompi_coll_base_retain_op() expects ompi_coll_base_nbc_request_t, not ompi_request_t.

Signed-off-by: Joseph Schuchart schuchart@hlrs.de