### PR TITLE
ADAPT ireduce: reduce number of memory allocations

### DIFF
--- a/ompi/mca/coll/adapt/coll_adapt_context.c
+++ b/ompi/mca/coll/adapt/coll_adapt_context.c
@@ -3,14 +3,29 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * $COPYRIGHT$
- * 
+ *
  * Additional copyrights may follow
- * 
+ *
  * $HEADER$
  */
 
 #include "ompi/mca/coll/coll.h"
 #include "coll_adapt_context.h"
+
+
+static void adapt_constant_reduce_context_construct(ompi_coll_adapt_constant_reduce_context_t *context)
+{
+    OBJ_CONSTRUCT(&context->recv_list, opal_list_t);
+    OBJ_CONSTRUCT(&context->mutex_recv_list, opal_mutex_t);
+    OBJ_CONSTRUCT(&context->inbuf_list, opal_free_list_t);
+}
+
+static void adapt_constant_reduce_context_destruct(ompi_coll_adapt_constant_reduce_context_t *context)
+{
+    OBJ_DESTRUCT(&context->mutex_recv_list);
+    OBJ_DESTRUCT(&context->recv_list);
+    OBJ_DESTRUCT(&context->inbuf_list);
+}
 
 
 OBJ_CLASS_INSTANCE(ompi_coll_adapt_bcast_context_t, opal_free_list_item_t,
@@ -23,4 +38,5 @@ OBJ_CLASS_INSTANCE(ompi_coll_adapt_reduce_context_t, opal_free_list_item_t,
                    NULL, NULL);
 
 OBJ_CLASS_INSTANCE(ompi_coll_adapt_constant_reduce_context_t, opal_object_t,
-                   NULL, NULL);
+                   &adapt_constant_reduce_context_construct,
+                   &adapt_constant_reduce_context_destruct);

--- a/ompi/mca/coll/adapt/coll_adapt_context.h
+++ b/ompi/mca/coll/adapt/coll_adapt_context.h
@@ -3,9 +3,9 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * $COPYRIGHT$
- * 
+ *
  * Additional copyrights may follow
- * 
+ *
  * $HEADER$
  */
 
@@ -74,16 +74,19 @@ struct ompi_coll_adapt_constant_reduce_context_s {
     /* Increment of each segment */
     int segment_increment;
     int num_segs;
-    ompi_request_t *request;
     int rank;
+    int root;
+    /* The distance between the address of inbuf->buff and the address of inbuf */
+    int distance;
+    int ireduce_tag;
+    /* How many sends are posted but not finished */
+    int32_t ongoing_send;
     /* Length of the fragment array, which is the number of recevied segments */
-    opal_atomic_int32_t num_recv_segs;
+    int32_t num_recv_segs;
     /* Number of sent segments */
-    opal_atomic_int32_t num_sent_segs;
+    int32_t num_sent_segs;
     /* Next seg need to be received for every children */
-    opal_atomic_int32_t *next_recv_segs;
-    /* Mutex to protect recv_list */
-    opal_mutex_t *mutex_recv_list;
+    int32_t *next_recv_segs;
     /* Mutex to protect each segment when do the reduce op */
     opal_mutex_t *mutex_op_list;
     /* Reduce operation */
@@ -91,20 +94,15 @@ struct ompi_coll_adapt_constant_reduce_context_s {
     ompi_coll_tree_t *tree;
     /* Accumulate buff */
     char **accumbuf;
-    /* inbuf list address of accumbuf */ 
-    ompi_coll_adapt_inbuf_t ** accumbuf_to_inbuf;  
-    opal_free_list_t *inbuf_list;
-    /* A list to store the segments which are received and not yet be sent */
-    opal_list_t *recv_list;
     ptrdiff_t lower_bound;
-    /* How many sends are posted but not finished */
-    opal_atomic_int32_t ongoing_send;
     char *sbuf;
     char *rbuf;
-    int root;
-    /* The distance between the address of inbuf->buff and the address of inbuf */
-    int distance;
-    int ireduce_tag;
+    opal_free_list_t inbuf_list;
+    /* Mutex to protect recv_list */
+    opal_mutex_t mutex_recv_list;
+    /* A list to store the segments which are received and not yet be sent */
+    opal_list_t recv_list;
+    ompi_request_t *request;
 };
 
 typedef struct ompi_coll_adapt_constant_reduce_context_s ompi_coll_adapt_constant_reduce_context_t;
@@ -119,7 +117,7 @@ typedef int (*ompi_coll_adapt_reduce_cuda_callback_fn_t) (ompi_coll_adapt_reduce
 struct ompi_coll_adapt_reduce_context_s {
     opal_free_list_item_t super;
     char *buff;
-    int frag_id;
+    int seg_index;
     int child_id;
     int peer;
     ompi_coll_adapt_constant_reduce_context_t *con;


### PR DESCRIPTION
Cut down the number of allocations done in ireduce by melting things into the connection object and remove some atomic variables to reduce `mfence` instructions.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>