### PR TITLE
COLL HAN: Don't try to free a static string, strdup it instead

### DIFF
--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -551,10 +551,10 @@ static const char* colltype_translation_table[] = {
     [COLLCOUNT] = NULL
 };
 
-const char* mca_coll_base_colltype_to_str(int collid)
+char* mca_coll_base_colltype_to_str(int collid)
 {
     if( (collid < 0) || (collid >= COLLCOUNT) ) {
         return NULL;
     }
-    return colltype_translation_table[collid];
+    return strdup(colltype_translation_table[collid]);
 }

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -150,7 +150,7 @@ int ompi_coll_base_file_getnext_string(FILE *fptr, int *fileline, char** val);
 int ompi_coll_base_file_peek_next_char_is(FILE *fptr, int *fileline, int expected);
 
 /* Miscelaneous function */
-const char* mca_coll_base_colltype_to_str(int collid);
+char* mca_coll_base_colltype_to_str(int collid);
 int mca_coll_base_name_to_colltype(const char* name);
 
 END_C_DECLS

--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -142,7 +142,8 @@ mca_coll_han_init_dynamic_rules(void)
                                     coll_name, fileline, ALLGATHER, COLLCOUNT);
                 goto file_reading_error;
             }
-            coll_name = (char*)mca_coll_base_colltype_to_str(coll_id);
+            free(coll_name);
+            coll_name = mca_coll_base_colltype_to_str(coll_id);
         }
 
         if(!mca_coll_han_is_coll_dynamic_implemented(coll_id)) {


### PR DESCRIPTION
This is why you don't just cast away `const`...

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>