### PR TITLE
Redo the initialization of all HAN collectives.

### DIFF
--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -420,7 +420,15 @@ static inline struct ompi_proc_t *ompi_group_peer_lookup_existing (ompi_group_t 
     return ompi_group_get_proc_ptr (group, peer_id, false);
 }
 
+/**
+ * Return true if all processes in the group are not on the local node.
+ */
 bool ompi_group_have_remote_peers (ompi_group_t *group);
+
+/**
+ * Count the number of processes on the local node.
+ */
+int ompi_group_count_local_peers (ompi_group_t *group);
 
 /**
  *  Function to print the group info

--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -255,7 +255,6 @@ typedef struct mca_coll_han_module_t {
     /* Whether this module has been lazily initialized or not yet */
     bool enabled;
 
-    struct ompi_communicator_t *cached_comm;
     struct ompi_communicator_t **cached_low_comms;
     struct ompi_communicator_t **cached_up_comms;
     int *cached_vranks;
@@ -331,8 +330,8 @@ mca_coll_base_module_t *mca_coll_han_comm_query(struct ompi_communicator_t *comm
 int han_request_free(ompi_request_t ** request);
 
 /* Subcommunicator creation */
-void mca_coll_han_comm_create(struct ompi_communicator_t *comm, mca_coll_han_module_t * han_module);
-void mca_coll_han_comm_create_new(struct ompi_communicator_t *comm, mca_coll_han_module_t *han_module);
+int mca_coll_han_comm_create(struct ompi_communicator_t *comm, mca_coll_han_module_t * han_module);
+int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm, mca_coll_han_module_t *han_module);
 /* Gather topology information */
 int *mca_coll_han_topo_init(struct ompi_communicator_t *comm, mca_coll_han_module_t * han_module,
                             int num_topo_level);

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -67,7 +67,17 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
 {
     /* Create the subcommunicators */
     mca_coll_han_module_t *han_module = (mca_coll_han_module_t *) module;
-    mca_coll_han_comm_create_new(comm, han_module);
+    if( OMPI_SUCCESS != mca_coll_han_comm_create_new(comm, han_module) ) {
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "han cannot handle allgather within this communicator. Fall back on another component\n"));
+        /* Put back the fallback collective support and call it once. All
+         * future calls will then be automatically redirected.
+         */
+        comm->c_coll->coll_allgather = han_module->fallback.allgather.allgather;
+        comm->c_coll->coll_allgather_module = han_module->fallback.allgather.module;
+        return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                            comm, comm->c_coll->coll_allgather_module);
+    }
     ompi_communicator_t *low_comm = han_module->sub_comm[INTRA_NODE];
     ompi_communicator_t *up_comm = han_module->sub_comm[INTER_NODE];
     int low_rank = ompi_comm_rank(low_comm);
@@ -75,11 +85,10 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
 
     /* Init topo */
     int *topo = mca_coll_han_topo_init(comm, han_module, 2);
-
     /* unbalanced case needs algo adaptation */
-    if (han_module->are_ppn_imbalanced){
+    if (han_module->are_ppn_imbalanced) {
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
-                             "han cannot handle allgather with this communicator. It need to fall back on another component\n"));
+                             "han cannot handle allgather with this communicator (imbalance). Fall back on another component\n"));
         return han_module->previous_allgather(sbuf, scount, sdtype, rbuf,
                                               rcount, rdtype,
                                               comm, han_module->previous_allgather_module);
@@ -118,7 +127,7 @@ int mca_coll_han_allgather_lg_task(void *task_args)
     mca_coll_han_allgather_t *t = (mca_coll_han_allgather_t *) task_args;
     char *tmp_buf = NULL, *tmp_rbuf = NULL;
     char *tmp_send = NULL;
-    
+
     OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output, "[%d] HAN Allgather:  lg\n",
                          t->w_rank));
 
@@ -159,7 +168,7 @@ int mca_coll_han_allgather_lg_task(void *task_args)
                                          t->rdtype, t->root_low_rank, t->low_comm,
                                          t->low_comm->c_coll->coll_gather_module);
     }
-    
+
     t->sbuf = tmp_rbuf;
     t->sbuf_inter_free = tmp_buf;
 
@@ -280,22 +289,36 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
 
     /* create the subcommunicators */
     mca_coll_han_module_t *han_module = (mca_coll_han_module_t *)module;
-    mca_coll_han_comm_create_new(comm, han_module);
-    ompi_communicator_t *low_comm = han_module->sub_comm[INTRA_NODE];
-    ompi_communicator_t *up_comm = han_module->sub_comm[INTER_NODE];
 
+    if( OMPI_SUCCESS != mca_coll_han_comm_create_new(comm, han_module) ) {
+        OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
+                             "han cannot handle allgather within this communicator. Fall back on another component\n"));
+        /* Put back the fallback collective support and call it once. All
+         * future calls will then be automatically redirected.
+         */
+        comm->c_coll->coll_allgather = han_module->fallback.allgather.allgather;
+        comm->c_coll->coll_allgather_module = han_module->fallback.allgather.module;
+        return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                            comm, comm->c_coll->coll_allgather_module);
+    }
     /* discovery topology */
     int *topo = mca_coll_han_topo_init(comm, han_module, 2);
 
     /* unbalanced case needs algo adaptation */
-    if (han_module->are_ppn_imbalanced){
+    if (han_module->are_ppn_imbalanced) {
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
-                             "han cannot handle allgather with this communicator. It need to fall back on another component\n"));
-        return han_module->previous_allgather(sbuf, scount, sdtype, rbuf,
-                                              rcount, rdtype,
-                                              comm, han_module->previous_allgather_module);
+                             "han cannot handle allgather within this communicator (imbalance). Fall back on another component\n"));
+        /* Put back the fallback collective support and call it once. All
+         * future calls will then be automatically redirected.
+         */
+        comm->c_coll->coll_allgather = han_module->fallback.gather.allgather;
+        comm->c_coll->coll_allgather_module = han_module->fallback.allgather.module;
+        return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                            comm, comm->c_coll->coll_allgather_module);
     }
 
+    ompi_communicator_t *low_comm = han_module->sub_comm[INTRA_NODE];
+    ompi_communicator_t *up_comm = han_module->sub_comm[INTER_NODE];
     int w_rank = ompi_comm_rank(comm);
     /* setup up/low coordinates */
     int low_rank = ompi_comm_rank(low_comm);

--- a/ompi/mca/coll/han/coll_han_dynamic_file.c
+++ b/ompi/mca/coll/han/coll_han_dynamic_file.c
@@ -117,10 +117,6 @@ mca_coll_han_init_dynamic_rules(void)
         coll_rules[i].nb_topologic_levels = 0;
         mca_coll_han_component.dynamic_rules.nb_collectives = i+1;
 
-        if( NULL != coll_name ) {
-            free(coll_name);
-            coll_name = NULL;
-        }
         /* Get the collective identifier */
         if( getnext_string(fptr, &coll_name) < 0 ) {
             opal_output_verbose(5, mca_coll_han_component.han_output,
@@ -361,24 +357,21 @@ mca_coll_han_init_dynamic_rules(void)
                 }
             }
         }
-    }
-    if( NULL != coll_name ) {
-        free(coll_name);
-        coll_name = NULL;
+        if( NULL != coll_name ) {
+            free(coll_name);
+            coll_name = NULL;
+        }
     }
 
-    if( getnext_long(fptr, &nb_coll) ) {
+    if( getnext_long(fptr, &nb_coll) > 0 ) {
         opal_output_verbose(5, mca_coll_han_component.han_output,
-                            "coll:han:mca_coll_han_init_dynamic_rules "
-                            "Warning on file %s at line %d: "
-                            "rule reading is over but reader does not seem "
-                            "to have reached the end of the file\n",
+                            "coll:han:mca_coll_han_init_dynamic_rules. Warning on file %s at line %d: "
+                            "rule reading is over but reader does not seem to have reached the end of the file\n",
                             fname, fileline);
     }
 
     opal_output_verbose(5, mca_coll_han_component.han_output,
-                        "coll:han:mca_coll_han_init_dynamic_rules "
-                        "read %d rules from %s\n",
+                        "coll:han:mca_coll_han_init_dynamic_rules read %d rules from %s\n",
                         nb_entries, fname);
 
     if(mca_coll_han_component.dump_dynamic_rules) {

--- a/ompi/mca/coll/han/coll_han_module.c
+++ b/ompi/mca/coll/han/coll_han_module.c
@@ -56,7 +56,6 @@ static void mca_coll_han_module_construct(mca_coll_han_module_t * module)
 
     module->enabled = false;
     module->super.coll_module_disable = mca_coll_han_module_disable;
-    module->cached_comm = NULL;
     module->cached_low_comms = NULL;
     module->cached_up_comms = NULL;
     module->cached_vranks = NULL;
@@ -179,7 +178,13 @@ mca_coll_han_comm_query(struct ompi_communicator_t * comm, int *priority)
                             comm->c_contextid, comm->c_name);
         return NULL;
     }
-
+    if( !ompi_group_have_remote_peers(comm->c_local_group) ) {
+        /* The group only contains local processes. Disable HAN for now */
+        opal_output_verbose(10, ompi_coll_base_framework.framework_output,
+                            "coll:han:comm_query (%d/%s): comm has only local processes; disqualifying myself",
+                            comm->c_contextid, comm->c_name);
+        return NULL;
+    }
     /* Get the priority level attached to this module. If priority is less
      * than or equal to 0, then the module is unavailable. */
     *priority = mca_coll_han_component.han_priority;

--- a/ompi/mca/coll/han/coll_han_topo.c
+++ b/ompi/mca/coll/han/coll_han_topo.c
@@ -245,13 +245,11 @@ mca_coll_han_topo_are_ppn_imbalanced(int *topo,
                                      int num_topo_level)
 {
     int size = ompi_comm_size(comm);
-    int i;
 
     if (size < 2) {
         return false;
     }
-    int ppn;
-    int last_host = topo[0];
+    int i, ppn, last_host = topo[0];
 
     /* Find the ppn for the first node */
     for (i = 1; i < size; i++) {
@@ -304,44 +302,37 @@ mca_coll_han_topo_init(struct ompi_communicator_t *comm,
                        mca_coll_han_module_t *han_module,
                        int num_topo_level)
 {
-    int size, *topo = han_module->cached_topo;
-
-    size = ompi_comm_size(comm);
-
-    if (!(topo && (han_module->cached_comm == comm))) {
-        if (han_module->cached_topo) {
-            free(han_module->cached_topo);
-            han_module->cached_topo = NULL;
-        }
-
-        topo = (int *)malloc(sizeof(int) * size * num_topo_level);
-
-        /* get topo infomation */
-        mca_coll_han_topo_get(topo, comm, num_topo_level);
-
-        /*
-         * All the ranks now have the topo information
-         */
-
-        /* check if the processes are mapped by core */
-        han_module->is_mapbycore = mca_coll_han_topo_is_mapbycore(topo, comm, num_topo_level);
-
-        /*
-         * If not, sort the topo such that each group of ids is sorted by rank
-         * i.e. ids for rank i are contiguous to ids for rank i+1.
-         * This will be needed for the operations that are order sensitive
-         * (like gather)
-         */
-        if (!han_module->is_mapbycore) {
-            mca_coll_han_topo_sort(topo, 0, size-1, 0, num_topo_level);
-        }
-        han_module->are_ppn_imbalanced = mca_coll_han_topo_are_ppn_imbalanced(topo, comm , num_topo_level);
-        han_module->cached_topo = topo;
-        han_module->cached_comm = comm;
-#if OPAL_ENABLE_DEBUG
-        mca_coll_han_topo_print(topo, comm, num_topo_level);
-#endif  /* OPAL_ENABLE_DEBUG */
+    if ( NULL != han_module->cached_topo ) {
+        return han_module->cached_topo;
     }
+
+    int size = ompi_comm_size(comm);
+    int *topo = (int *)malloc(sizeof(int) * size * num_topo_level);
+
+    /* get topo information */
+    mca_coll_han_topo_get(topo, comm, num_topo_level);
+
+    /*
+     * All the ranks now have the topo information
+     */
+
+    /* check if the processes are mapped by core */
+    han_module->is_mapbycore = mca_coll_han_topo_is_mapbycore(topo, comm, num_topo_level);
+
+    /*
+     * If not, sort the topo such that each group of ids is sorted by rank
+     * i.e. ids for rank i are contiguous to ids for rank i+1.
+     * This will be needed for the operations that are order sensitive
+     * (like gather)
+     */
+    if (!han_module->is_mapbycore) {
+        mca_coll_han_topo_sort(topo, 0, size-1, 0, num_topo_level);
+    }
+    han_module->are_ppn_imbalanced = mca_coll_han_topo_are_ppn_imbalanced(topo, comm, num_topo_level);
+    han_module->cached_topo = topo;
+#if OPAL_ENABLE_DEBUG
+    mca_coll_han_topo_print(topo, comm, num_topo_level);
+#endif  /* OPAL_ENABLE_DEBUG */
 
     return topo;
 }

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -176,7 +176,7 @@ mca_coll_sm_comm_query(struct ompi_communicator_t *comm, int *priority)
     if (OMPI_COMM_IS_INTER(comm) || 1 == ompi_comm_size(comm) || ompi_group_have_remote_peers (comm->c_local_group)) {
         opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                             "coll:sm:comm_query (%d/%s): intercomm, comm is too small, or not all peers local; disqualifying myself", comm->c_contextid, comm->c_name);
-	return NULL;
+        return NULL;
     }
 
     /* Get the priority level attached to this module. If priority is less


### PR DESCRIPTION
Implement a fallback allowing a HAN module to remove itself as potential active
collective module, and instead fallback to the next module in line.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>