### PR TITLE
COLL HAN: Correctly retain and release coll modules when loading fallback

### DIFF
--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -315,6 +315,17 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 #define previous_scatter            fallback.scatter.scatter
 #define previous_scatter_module     fallback.scatter.module
 
+
+/* macro to correctly load a fallback collective module */
+#define HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, COLL)          \
+    do {                                                                         \
+        (COMM)->c_coll->coll_ ## COLL = (HANM)->fallback.COLL.COLL;               \
+        mca_coll_base_module_t *coll_module = (COMM)->c_coll->coll_ ## COLL ## _module; \
+        (COMM)->c_coll->coll_ ## COLL ## _module = (HANM)->fallback.COLL.module;  \
+        OBJ_RETAIN((COMM)->c_coll->coll_ ## COLL ## _module);                     \
+        OBJ_RELEASE(coll_module);                                                 \
+    } while(0)
+
 /**
  * Global component instance
  */

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -73,8 +73,7 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_allgather = han_module->fallback.allgather.allgather;
-        comm->c_coll->coll_allgather_module = han_module->fallback.allgather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, allgather);
         return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
                                             comm, comm->c_coll->coll_allgather_module);
     }
@@ -89,9 +88,9 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
     if (han_module->are_ppn_imbalanced) {
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "han cannot handle allgather with this communicator (imbalance). Fall back on another component\n"));
-        return han_module->previous_allgather(sbuf, scount, sdtype, rbuf,
-                                              rcount, rdtype,
-                                              comm, han_module->previous_allgather_module);
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, allgather);
+        return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                            comm, comm->c_coll->coll_allgather_module);
     }
 
     ompi_request_t *temp_request = NULL;
@@ -296,8 +295,7 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_allgather = han_module->fallback.allgather.allgather;
-        comm->c_coll->coll_allgather_module = han_module->fallback.allgather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, allgather);
         return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
                                             comm, comm->c_coll->coll_allgather_module);
     }
@@ -311,8 +309,7 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_allgather = han_module->fallback.gather.allgather;
-        comm->c_coll->coll_allgather_module = han_module->fallback.allgather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, allgather);
         return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
                                             comm, comm->c_coll->coll_allgather_module);
     }

--- a/ompi/mca/coll/han/coll_han_bcast.c
+++ b/ompi/mca/coll/han/coll_han_bcast.c
@@ -76,8 +76,7 @@ mca_coll_han_bcast_intra(void *buff,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_bcast = han_module->fallback.bcast.bcast;
-        comm->c_coll->coll_bcast_module = han_module->fallback.bcast.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, bcast);
         return comm->c_coll->coll_bcast(buff, count, dtype, root,
                                         comm, comm->c_coll->coll_bcast_module);
     }
@@ -90,8 +89,7 @@ mca_coll_han_bcast_intra(void *buff,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_bcast = han_module->fallback.bcast.bcast;
-        comm->c_coll->coll_bcast_module = han_module->fallback.bcast.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, bcast);
         return comm->c_coll->coll_bcast(buff, count, dtype, root,
                                         comm, comm->c_coll->coll_bcast_module);
     }
@@ -231,8 +229,7 @@ mca_coll_han_bcast_intra_simple(void *buff,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_bcast = han_module->fallback.bcast.bcast;
-        comm->c_coll->coll_bcast_module = han_module->fallback.bcast.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, bcast);
         return comm->c_coll->coll_bcast(buff, count, dtype, root,
                                         comm, comm->c_coll->coll_bcast_module);
     }
@@ -245,8 +242,7 @@ mca_coll_han_bcast_intra_simple(void *buff,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_bcast = han_module->fallback.bcast.bcast;
-        comm->c_coll->coll_bcast_module = han_module->fallback.bcast.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, bcast);
         return comm->c_coll->coll_bcast(buff, count, dtype, root,
                                         comm, comm->c_coll->coll_bcast_module);
     }

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -81,8 +81,7 @@ mca_coll_han_gather_intra(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_gather = han_module->fallback.gather.gather;
-        comm->c_coll->coll_gather_module = han_module->fallback.gather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gather);
         return comm->c_coll->coll_gather(sbuf, scount, sdtype, rbuf,
                                          rcount, rdtype, root,
                                          comm, comm->c_coll->coll_gather_module);
@@ -97,8 +96,7 @@ mca_coll_han_gather_intra(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_gather = han_module->fallback.gather.gather;
-        comm->c_coll->coll_gather_module = han_module->fallback.gather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gather);
         return comm->c_coll->coll_gather(sbuf, scount, sdtype, rbuf,
                                          rcount, rdtype, root,
                                          comm, comm->c_coll->coll_gather_module);
@@ -303,8 +301,7 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_gather = han_module->fallback.gather.gather;
-        comm->c_coll->coll_gather_module = han_module->fallback.gather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gather);
         return comm->c_coll->coll_gather(sbuf, scount, sdtype, rbuf,
                                          rcount, rdtype, root,
                                          comm, comm->c_coll->coll_gather_module);
@@ -319,8 +316,7 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        comm->c_coll->coll_gather = han_module->fallback.gather.gather;
-        comm->c_coll->coll_gather_module = han_module->fallback.gather.module;
+        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gather);
         return comm->c_coll->coll_gather(sbuf, scount, sdtype, rbuf,
                                          rcount, rdtype, root,
                                          comm, comm->c_coll->coll_gather_module);

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -169,8 +169,7 @@ mca_coll_han_reduce_intra(const void *sbuf,
     /* Put back the fallback collective support and call it once. All
      * future calls will then be automatically redirected.
      */
-    comm->c_coll->coll_reduce = han_module->fallback.reduce.reduce;
-    comm->c_coll->coll_reduce_module = han_module->fallback.reduce.module;
+    HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, reduce);
     return comm->c_coll->coll_reduce(sbuf, rbuf, count, dtype, op, root,
                                      comm, comm->c_coll->coll_reduce_module);
 }
@@ -347,8 +346,7 @@ mca_coll_han_reduce_intra_simple(const void *sbuf,
     /* Put back the fallback collective support and call it once. All
      * future calls will then be automatically redirected.
      */
-    comm->c_coll->coll_reduce = han_module->fallback.reduce.reduce;
-    comm->c_coll->coll_reduce_module = han_module->fallback.reduce.module;
+    HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, reduce);
     return comm->c_coll->coll_reduce(sbuf, rbuf, count, dtype, op, root,
                                      comm, comm->c_coll->coll_reduce_module);
 }

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -170,8 +170,7 @@ mca_coll_han_scatter_intra(const void *sbuf, int scount,
     /* Put back the fallback collective support and call it once. All
      * future calls will then be automatically redirected.
      */
-    comm->c_coll->coll_scatter = han_module->fallback.scatter.scatter;
-    comm->c_coll->coll_scatter_module = han_module->fallback.scatter.module;
+    HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, scatter);
     return comm->c_coll->coll_scatter(sbuf, scount, sdtype, rbuf, rcount, rdtype, root,
                                       comm, comm->c_coll->coll_scatter_module);
 }


### PR DESCRIPTION
Also remove fallback in case of imbalanced ranks for allgather as that is not needed.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>