### PR TITLE
COLL HAN: fallback on all communicators if subcommunicator creation fails

### DIFF
--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -319,13 +319,27 @@ OBJ_CLASS_DECLARATION(mca_coll_han_module_t);
 /* macro to correctly load a fallback collective module */
 #define HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, COLL)                            \
     do {                                                                          \
-        assert( ((COMM)->c_coll->coll_ ## COLL ## _module) == (mca_coll_base_module_t*)(HANM) );           \
-        (COMM)->c_coll->coll_ ## COLL = (HANM)->fallback.COLL.COLL;               \
-        mca_coll_base_module_t *coll_module = (COMM)->c_coll->coll_ ## COLL ## _module; \
-        (COMM)->c_coll->coll_ ## COLL ## _module = (HANM)->fallback.COLL.module;  \
-        OBJ_RETAIN((COMM)->c_coll->coll_ ## COLL ## _module);                     \
-        OBJ_RELEASE(coll_module);                                                 \
+        if ( ((COMM)->c_coll->coll_ ## COLL ## _module) == (mca_coll_base_module_t*)(HANM) ) { \
+            (COMM)->c_coll->coll_ ## COLL = (HANM)->fallback.COLL.COLL;               \
+            mca_coll_base_module_t *coll_module = (COMM)->c_coll->coll_ ## COLL ## _module; \
+            (COMM)->c_coll->coll_ ## COLL ## _module = (HANM)->fallback.COLL.module;  \
+            OBJ_RETAIN((COMM)->c_coll->coll_ ## COLL ## _module);                     \
+            OBJ_RELEASE(coll_module);                                                 \
+        }                                                                             \
     } while(0)
+
+/* macro to correctly load /all/ fallback collectives */
+#define HAN_LOAD_FALLBACK_COLLECTIVES(HANM, COMM)                            \
+    do {                                                                     \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, bcast);                     \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, scatter);                   \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, gather);                    \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, reduce);                    \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, allreduce);                 \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, allgather);                 \
+        HAN_LOAD_FALLBACK_COLLECTIVE(HANM, COMM, allgatherv);                \
+    } while(0)
+
 
 /**
  * Global component instance

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -70,10 +70,8 @@ mca_coll_han_allgather_intra(const void *sbuf, int scount,
     if( OMPI_SUCCESS != mca_coll_han_comm_create_new(comm, han_module) ) {
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "han cannot handle allgather within this communicator. Fall back on another component\n"));
-        /* Put back the fallback collective support and call it once. All
-         * future calls will then be automatically redirected.
-         */
-        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, allgather);
+        /* HAN cannot work with this communicator so fallback on all collectives */
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
                                             comm, comm->c_coll->coll_allgather_module);
     }
@@ -292,10 +290,8 @@ mca_coll_han_allgather_intra_simple(const void *sbuf, int scount,
     if( OMPI_SUCCESS != mca_coll_han_comm_create_new(comm, han_module) ) {
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "han cannot handle allgather within this communicator. Fall back on another component\n"));
-        /* Put back the fallback collective support and call it once. All
-         * future calls will then be automatically redirected.
-         */
-        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, allgather);
+        /* HAN cannot work with this communicator so fallback on all collectives */
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_allgather(sbuf, scount, sdtype, rbuf, rcount, rdtype,
                                             comm, comm->c_coll->coll_allgather_module);
     }

--- a/ompi/mca/coll/han/coll_han_bcast.c
+++ b/ompi/mca/coll/han/coll_han_bcast.c
@@ -76,7 +76,7 @@ mca_coll_han_bcast_intra(void *buff,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, bcast);
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_bcast(buff, count, dtype, root,
                                         comm, comm->c_coll->coll_bcast_module);
     }
@@ -229,7 +229,7 @@ mca_coll_han_bcast_intra_simple(void *buff,
         /* Put back the fallback collective support and call it once. All
          * future calls will then be automatically redirected.
          */
-        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, bcast);
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_bcast(buff, count, dtype, root,
                                         comm, comm->c_coll->coll_bcast_module);
     }

--- a/ompi/mca/coll/han/coll_han_gather.c
+++ b/ompi/mca/coll/han/coll_han_gather.c
@@ -78,10 +78,8 @@ mca_coll_han_gather_intra(const void *sbuf, int scount,
     if( OMPI_SUCCESS != err ) {  /* Let's hope the error is consistently returned across the entire communicator */
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "han cannot handle gather with this communicator. Fall back on another component\n"));
-        /* Put back the fallback collective support and call it once. All
-         * future calls will then be automatically redirected.
-         */
-        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gather);
+        /* HAN cannot work with this communicator so fallback on all collectives */
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_gather(sbuf, scount, sdtype, rbuf,
                                          rcount, rdtype, root,
                                          comm, comm->c_coll->coll_gather_module);
@@ -298,10 +296,8 @@ mca_coll_han_gather_intra_simple(const void *sbuf, int scount,
     if( OMPI_SUCCESS != mca_coll_han_comm_create_new(comm, han_module) ) {  /* Let's hope the error is consistently returned across the entire communicator */
         OPAL_OUTPUT_VERBOSE((30, mca_coll_han_component.han_output,
                              "han cannot handle gather with this communicator. Fall back on another component\n"));
-        /* Put back the fallback collective support and call it once. All
-         * future calls will then be automatically redirected.
-         */
-        HAN_LOAD_FALLBACK_COLLECTIVE(han_module, comm, gather);
+        /* HAN cannot work with this communicator so fallback on all collectives */
+        HAN_LOAD_FALLBACK_COLLECTIVES(han_module, comm);
         return comm->c_coll->coll_gather(sbuf, scount, sdtype, rbuf,
                                          rcount, rdtype, root,
                                          comm, comm->c_coll->coll_gather_module);

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -95,6 +95,14 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
                                  MPI_MAX, comm,
                                  comm->c_coll->coll_allreduce_module);
     if( local_procs == 1 ) {
+        /* restore saved collectives */
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allgatherv);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allgather);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allreduce);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, bcast);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, reduce);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
@@ -223,6 +231,14 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
                                  MPI_MAX, comm,
                                  comm->c_coll->coll_allreduce_module);
     if( local_procs == 1 ) {
+        /* restore saved collectives */
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allgatherv);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allgather);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, allreduce);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, bcast);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, reduce);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, gather);
+        HAN_SUBCOM_LOAD_COLLECTIVE(fallbacks, comm, han_module, scatter);
         return OMPI_ERR_NOT_SUPPORTED;
     }
 


### PR DESCRIPTION
Load all fallback collectives if communicator creation fails. That requires restoring saved collectives in `mca_coll_han_comm_create`. 